### PR TITLE
NetDB: Increase min FF version for LS lookups since most are LS2 now …

### DIFF
--- a/router/java/src/net/i2p/router/networkdb/kademlia/IterativeSearchJob.java
+++ b/router/java/src/net/i2p/router/networkdb/kademlia/IterativeSearchJob.java
@@ -322,7 +322,7 @@ public class IterativeSearchJob extends FloodSearchJob {
                 // querying old floodfills that don't know about those sig types.
                 // This is also more recent than the version that supports encrypted replies,
                 // so we won't request unencrypted replies anymore either.
-                if (!StoreJob.shouldStoreTo(ri)) {
+                if (!StoreJob.shouldStoreTo(ri) || (_isLease && !StoreJob.shouldStoreLS2To(ri))) {
                     failed(peer, false);
                     if (_log.shouldLog(Log.DEBUG))
                         _log.debug("[Job " + getJobId() + "] Not sending query to old Router [" + ri.toBase64().substring(0,6) + "]");


### PR DESCRIPTION
…[upstream]

(manually cherry-picked from commit 875fcdfb94f0703dbe366e3c1836a2cdce6ae764)